### PR TITLE
update readme, fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,83 @@
-# swell-docs
+# 📚 Swellchain Docs
 
-This is a Next.js application generated with
-[Create Fumadocs](https://github.com/fuma-nama/fumadocs).
+<div align="center">
 
-Run development server:
+[![Next.js](https://img.shields.io/badge/Next.js-15.1.2-black?logo=next.js)](https://nextjs.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.7.2-blue?logo=typescript)](https://www.typescriptlang.org/)
+[![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-3.4.15-38B2AC?logo=tailwind-css)](https://tailwindcss.com/)
+[![Fumadocs](https://img.shields.io/badge/Fumadocs-14.5.4-000000?logo=book)](https://fumadocs.vercel.app)
+
+</div>
+
+## Overview
+
+This repository contains the official documentation for Swellchain, a restaking focused L2 built with the OP Stack. The repo provides comprehensive guides, API references, and technical specifications for developers integrating with Swellchain.
+
+## 🛠️ Getting Started
+
+### Prerequisites
+
+- Node.js 18.x or later
+- pnpm (recommended), npm, or yarn
+
+### Installation
+
+1. Clone the repository:
 
 ```bash
-npm run dev
+git clone https://github.com/swellnetwork/swell-chain-docs.git
+cd swell-chain-docs
+```
+
+2. Install dependencies:
+
+```bash
+pnpm install
 # or
+npm install
+# or
+yarn install
+```
+
+3. Start the development server:
+
+```bash
 pnpm dev
+# or
+npm run dev
 # or
 yarn dev
 ```
 
-Open http://localhost:3000 with your browser to see the result.
+4. Open [http://localhost:3000](http://localhost:3000) in your browser to view the documentation.
 
-## Learn More
+## 📖 Documentation Structure
 
-To learn more about Next.js and Fumadocs, take a look at the following
-resources:
+- `/content` - Main documentation content in MDX format
+- `/components` - Reusable React components
+- `/lib` - Utility functions and shared logic
+- `/public` - Static assets and images
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js
-  features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-- [Fumadocs](https://fumadocs.vercel.app) - learn about Fumadocs
+## 🔧 Development
+
+- `pnpm build` - Build the production documentation
+- `pnpm start` - Start the production server
+- `pnpm lint` - Run ESLint
+- `pnpm type-check` - Run TypeScript type checking
+
+## 🤝 Contributing
+
+We welcome contributions! Feel free to submit a PR or open an issue.
+
+## 🔗 Links
+
+- [Swell Network Website](https://swellnetwork.io)
+- [Swellchain Documentation](https://docs.swellnetwork.io)
+- [GitHub Issues](https://github.com/swellnetwork/swell-chain-docs/issues)
+- [Discord Community](https://discord.gg/swellnetwork)
+
+---
+
+<div align="center">
+Made with ❤️ by Swell
+</div>

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -34,7 +34,7 @@ Start building on Swellchain with these essential resources:
   </Card>
   <Card
     icon={<Waypoints className="text-yellow-300" />}
-    href="/docs/developer-resources/rpc-providers-and-bridges#bridges"
+    href="/docs/developer-resources/bridges"
     title="Integrate Bridges"
   >
     Connect with Swellchain's cross-chain bridges


### PR DESCRIPTION
This pull request includes significant updates to the `README.md` file to enhance its structure and content, as well as a minor change to the `content/docs/index.mdx` file to update a link.

Improvements to documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R83): Updated the file to include new sections such as Overview, Getting Started, Documentation Structure, Development, and Contributing. Added badges for Next.js, TypeScript, Tailwind CSS, and Fumadocs. Improved the installation instructions and added more details about the documentation structure and development commands.

Minor link update:

* [`content/docs/index.mdx`](diffhunk://#diff-250d3cc5970e5f638367a1deacbc53ea566616f25faafa4ac5e613cd0598d10bL37-R37): Changed the link for integrating bridges to point directly to the `/docs/developer-resources/bridges` page instead of the specific section in the RPC providers and bridges page.